### PR TITLE
Change port for API

### DIFF
--- a/R/ausplots_queries.r
+++ b/R/ausplots_queries.r
@@ -2,7 +2,7 @@ require(httr)
 require(jsonlite)
 
 .ausplots_api <- function(path, query) {
-  resp <- httr::GET("http://swarmapi.ausplots.aekos.org.au:3000", path=path, query=query)
+  resp <- httr::GET("http://swarmapi.ausplots.aekos.org.au:80", path=path, query=query)
   stop_for_status(resp)
   if (http_type(resp) != "application/json") {
     stop("API did not return json", call. = FALSE)


### PR DESCRIPTION
Hey Greg,
we have some users from an institution that can't access the ausplots API that the ausplotsR package uses. I've redeployed the server so it can work with those firewalls (I think it'll work) but that means I needed to make a change to the package.

If you accept this pull request, my change will be merged into your repository and we'll be all set.