### PR TITLE
Support accented names in the DESCRIPTION file

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,12 +3,12 @@ Type: Package
 Title: TERN AusPlots analysis package
 Version: 1.2
 Date: 2020-05-11
-Author: Greg Guerin, Tom Saleeba, Samantha Munroe, Bernardo Blanco-Martin, Irene Martin-Fores, Andrew Tokmakoff
+Author: Greg Guerin, Tom Saleeba, Samantha Munroe, Bernardo Blanco-Martin, Irene Martín-Forés, Andrew Tokmakoff
 Authors@R: c(
     person("Greg", "Guerin", email = "ggueri01@gmail.com", role = c("aut", "cre")),
     person("Tom", "Saleeba", role = "aut"),
     person("Samantha", "Munroe", role = "aut"),
-    person("Irene", "Martin-Fores", role = "aut"),
+    person("Irene", "Martín-Forés", role = "aut"),
     person("Bernardo", "Blanco-Martin", role="aut"),
     person("Andrew", "Tokmakoff", role = "aut"))
 Maintainer: Greg Guerin <ggueri01@gmail.com>
@@ -39,3 +39,4 @@ License: GPL-3 + file LICENSE
 LazyData: TRUE
 VignetteBuilder: knitr
 RoxygenNote: 7.1.1
+Encoding: UTF-8


### PR DESCRIPTION
Héy @Sammunroe, I fíxéd ít. :sunglasses: 

UTF-8 is an encoding that includes every character you can think of, even ones to make a person flipping a table: (╯°□°)╯︵ ┻━┻ .

So by telling R that our file is encoded as UTF-8 and not the implicit default of ASCII, we can use accented characters.

This thing I'm sending you is called a Pull Request (PR). [Read more about them on GitHub's doco](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests). It's a way for me to make a change on a branch and _request_ that you to _pull_ my changes into _your_ branch. In this case I could just commit directly to your branch but I thought it was a good chance to use this feature. You should be able to accept this and it will merge the change into your branch.

It's worth pointing out that the [R doco](https://cran.r-project.org/doc/manuals/r-release/R-exts.html#The-DESCRIPTION-file) has this to say about setting an encoding for your package:

> If the DESCRIPTION file is not entirely in ASCII it should contain an ‘Encoding’ field specifying an encoding. This is used as the encoding of the DESCRIPTION file itself and of the R and NAMESPACE files, and as the default encoding of .Rd files. The examples are assumed to be in this encoding when running R CMD check, and it is used for the encoding of the CITATION file. Only encoding names latin1, latin2 and UTF-8 are known to be portable. (Do not specify an encoding unless one is actually needed: doing so makes the package less portable. If a package has a specified encoding, you should run R CMD build etc in a locale using that encoding.)

I'd argue that an encoding is actually needed. And I feel like that was written a long time ago when support for UTF-8 wasn't as good. These days I'd expect we won't have any portability (using the package anywhere) issues.